### PR TITLE
Bump MSTest.TestAdapter from 3.10.0 to 3.10.1

### DIFF
--- a/test/Hyperbee.Templating.Tests/Hyperbee.Templating.Tests.csproj
+++ b/test/Hyperbee.Templating.Tests/Hyperbee.Templating.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: MSTest.TestAdapter dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-patch ...

