### PR TITLE
Bump MSTest.TestFramework from 3.10.0 to 3.10.1

### DIFF
--- a/test/Hyperbee.Templating.Tests/Hyperbee.Templating.Tests.csproj
+++ b/test/Hyperbee.Templating.Tests/Hyperbee.Templating.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Hyperbee.XS.Extensions" Version="1.3.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.10.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: MSTest.TestFramework dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-patch ...

## Description

_Please include a brief summary of the changes. Mention any related issues or features._
 - `Fixes #<issue_number>_

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Checklist

- [ ] I have run the existing tests and they pass
- [ ] I have run the existing benchmarks and verified performance has not decreased
- [ ] I have added new tests that prove my change is effective or that my feature works
- [ ] I have added the necessary documentation (if applicable)
